### PR TITLE
[c] centered markdown content, excluding body text and headings

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -466,3 +466,19 @@ table td {
   align-items: center;
   grid-column-gap: 10px;
 }
+
+/* markdown content tweaks */
+
+section.body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+p, h1, h2, h3, h4, h5, h6, code, pre {
+  align-self: flex-start;
+}
+
+p.image-text {
+  align-self: center;
+}


### PR DESCRIPTION
With my changes, you can centre images, videos, or whatever else, with a configurable reset.

```css
/* starting at line 469 */
p, h1, h2, h3, h4, h5, h6, code, pre {
  align-self: flex-start;
}
```

The above code is a reset for elements that shouldn't be centred. Feel free to add onto that list, I've chosen some initial values.

You can also now centre and add an image's alt text like this in a post:

```html
<!-- example alt text for image -->
<img src="/imgs/Spyder-article/Spyder5.jpeg" alt="Spyder TKL Images" title="Image by extra Prius" class="TitleImage">
<p class="image-text">Photo by <a href="https://www.instagram.com/extrapriusplease.kb/">Extrapriusplease</a></p>
```

Add a paragraph with the `image-text` class to center it.

I hope my changes here have improved the looks of the website ;D